### PR TITLE
배경에 태양 올라오는 효과 추가, 벽 점프 조절할 수 잇는 메뉴 추가

### DIFF
--- a/Assets/Resources/BackGround/1_BG_2.png.meta
+++ b/Assets/Resources/BackGround/1_BG_2.png.meta
@@ -33,7 +33,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1

--- a/Assets/Resources/BackGround/1_BG_3.png.meta
+++ b/Assets/Resources/BackGround/1_BG_3.png.meta
@@ -33,7 +33,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1

--- a/Assets/Resources/BackGround/1_BG_4.png.meta
+++ b/Assets/Resources/BackGround/1_BG_4.png.meta
@@ -33,7 +33,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1

--- a/Assets/Resources/BackGround/1_BG_sun.png.meta
+++ b/Assets/Resources/BackGround/1_BG_sun.png.meta
@@ -33,7 +33,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1

--- a/Assets/Scenes/Stage1.unity
+++ b/Assets/Scenes/Stage1.unity
@@ -744,7 +744,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 146797757}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -4.450548, y: -10.202912, z: -66.451324}
+  m_LocalPosition: {x: -4.450548, y: -10.202912, z: -64.1}
   m_LocalScale: {x: 100, y: 100, z: 100}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1641,7 +1641,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.11111212, y: 10.286224, z: -10}
+  m_LocalPosition: {x: 0, y: 10.45, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2172,7 +2172,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &788919891
 BoxCollider2D:
@@ -2477,7 +2477,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 8
-  wallJumpPower: 14
   jumpForce: 16
   walljumpDir: 0
   moveDistance: {x: 0, y: 0}
@@ -2489,14 +2488,9 @@ MonoBehaviour:
   - {fileID: 394210134}
   - {fileID: 914674280}
   wallTime: 0
-  isJump: 0
-  isFloor: 0
-  isWire: 0
-  isWall: 0
-  isGrab: 0
-  JumpCount: 0
-  isWallJump: 0
   wallCondition: 0
+  wallJumpPower: 14
+  WallJumpTime: 0.15
 --- !u!120 &803172072
 LineRenderer:
   m_ObjectHideFlags: 0
@@ -3670,6 +3664,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1493412867}
+  - component: {fileID: 1493412868}
   m_Layer: 0
   m_Name: Background
   m_TagString: Untagged
@@ -3685,7 +3680,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1493412866}
   m_LocalRotation: {x: -1e-45, y: -1e-45, z: -0, w: 1}
-  m_LocalPosition: {x: 4.5616603, y: 12.946224, z: 81.451324}
+  m_LocalPosition: {x: 4.561661, y: 12.946224, z: 81.451324}
   m_LocalScale: {x: 1.15, y: 1.15, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -3694,8 +3689,23 @@ Transform:
   - {fileID: 2005966031}
   - {fileID: 146797759}
   m_Father: {fileID: 0}
-  m_RootOrder: 11
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1493412868
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493412866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96c54973e6513ad4ca8d4d338b44dcbc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Sun: {fileID: 1892161851}
+  FirstSunPos: {x: -6.363339, y: -10.05378, z: 10.65132}
+  FinalSunYPos: 15.56
 --- !u!1 &1494578177
 GameObject:
   m_ObjectHideFlags: 0
@@ -5069,7 +5079,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1836526645}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 30, y: -4.7, z: 0.14361814}
+  m_LocalPosition: {x: 11.9, y: -2.1, z: 0.14361814}
   m_LocalScale: {x: 6.4139996, y: 30, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5388,6 +5398,112 @@ Transform:
   m_Father: {fileID: 555396057}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1892161851
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1892161852}
+  - component: {fileID: 1892161853}
+  - component: {fileID: 1892161854}
+  m_Layer: 0
+  m_Name: 1_BG_sun
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1892161852
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892161851}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -7.0999994, y: 15.56, z: 10.651321}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1892161853
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892161851}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 88cd144d72a6c8842a9c95a964416377, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 64.01563, y: 25.6}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1892161854
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892161851}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da3bd2a18b1b31a4a83700ff4379f5a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ScrollSpeed: 0
+  FinalSpeed: 0
+  player: {fileID: 803172064}
+  p_move: {fileID: 0}
+  Camera: {fileID: 0}
+  p_LastPos: {x: 0, y: 0, z: 0}
+  p_MovedPos: {x: 0, y: 0, z: 0}
+  isMove: 0
+  isPlayerWall: 0
 --- !u!1 &1910178095
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BackGroundEffect.cs
+++ b/Assets/Scripts/BackGroundEffect.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BackGroundEffect : MonoBehaviour
+{
+    private bool SunRiseEnd;
+    [SerializeField] private GameObject Sun;
+    //[SerializeField] private SpriteRenderer Fog;
+
+    [SerializeField] private Vector3 FirstSunPos;
+    [SerializeField] private float FinalSunYPos;
+
+    void Awake()
+    {
+        SunRiseEnd = false;
+        Sun.transform.position = FirstSunPos;
+    }
+
+    void Update()
+    {
+        if (!SunRiseEnd)
+        {
+            SunRise();
+        }
+    }
+
+    private void SunRise()
+    {
+        Sun.transform.position += Vector3.up * Time.deltaTime;
+
+        if (Sun.transform.position.y >= FinalSunYPos)
+        {
+            Sun.transform.position= new Vector3(Sun.transform.position.x, FinalSunYPos, Sun.transform.position.z);
+            SunRiseEnd = true;
+        }
+    }
+}

--- a/Assets/Scripts/BackGroundEffect.cs.meta
+++ b/Assets/Scripts/BackGroundEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96c54973e6513ad4ca8d4d338b44dcbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerMove/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMove/PlayerMovement.cs
@@ -17,7 +17,6 @@ public class PlayerMovement : MonoBehaviour
     private ResetPosition p_Reset;
 
     [SerializeField] private float moveSpeed;
-    [SerializeField] private float wallJumpPower;
     [SerializeField] private float jumpForce;
     [SerializeField] private float walljumpDir;
     [SerializeField] Vector2 moveDistance;
@@ -33,15 +32,18 @@ public class PlayerMovement : MonoBehaviour
     public List<GameObject> jumpCounts = new List<GameObject>();
 
     [SerializeField] private float wallTime;
-
-    [SerializeField] private bool isJump;
-    [SerializeField] private bool isFloor;
-    [SerializeField] private bool isWire;
-    [SerializeField] private bool isWall;
-    [SerializeField] private bool isGrab;
-    [SerializeField] private int JumpCount;
-    [SerializeField] private bool isWallJump;
+    private bool isJump;
+    private bool isFloor;
+    private bool isWire;
+    private bool isWall;
+    private bool isGrab;
+    private int JumpCount;
+    private bool isWallJump;
     [SerializeField] private int wallCondition;//벽 상태 0: 벽에 붙지 않음, 1:벽에 닿아있음, 2:벽을 붙잡음, 3: 벽을 붙잡지 못하는 상태 4: 3의 상태에서 붙잡아서 천천히 내려옴 5: 벽점프
+
+    [Header("WallJump")]
+    [SerializeField] private float wallJumpPower;
+    [SerializeField] private float WallJumpTime;
 
     void Awake()
     {
@@ -150,7 +152,7 @@ public class PlayerMovement : MonoBehaviour
         //{
         //    jumpCounts[JumpCount - 1].SetActive(false);
         //}
-        yield return new WaitForSeconds(0.15f);
+        yield return new WaitForSeconds(WallJumpTime);
         wallCondition = 0;
     }
 


### PR DESCRIPTION
제 프로젝트에 보면 BackGroundEffect라는 스크립트가 추가되어있습니다.
배경 오브젝트, 배경 오브젝트의 시작 위치, 배경이 마지막에 위치할 Y축 값을 입력해주면 됩니다. 배경에는 BackGroundMove를 추가하고 속도는 0으로 하고 플레이어 오브젝트를 추가해주면 됩니다. 플레이어 벽점프는 WallJump 항목에 있는 것들을 조절하면 됩니다.
WallJumpPower는 벽점프로 가해지는 힘이고, WallJumpTime은 벽점프로 플레이어의 조작이 제한되는 시간입니다 이게 길어질수록 대각선으로 더 오래 나아갑니다